### PR TITLE
feat: Add response timing

### DIFF
--- a/lib/intercept.js
+++ b/lib/intercept.js
@@ -8,6 +8,7 @@ export default function intercept(request, recorder) {
   // read the request body as an array of Buffer chuncks
   // by hooking into the `request.{write,end}` methods.
   const requestBodyChunks = [];
+  const requestStart = (new Date()).valueOf();
   for (const method of ["write", "end"]) {
     const originalMethod = request[method];
     request[method] = function (chunk, encoding, callback) {
@@ -43,6 +44,7 @@ export default function intercept(request, recorder) {
         requestBody: requestBodyChunks,
         response,
         responseBody: responseBodyChunks,
+        elapsedTime: ((new Date()).valueOf() - requestStart)/1000,
       });
     });
   });


### PR DESCRIPTION
I'm working on a library which records the timing of HTTP requests in a test suite to generate metrics around slow HTTP requests, your library works great for intercepting these HTTP requests, but I can't see any easy way to record how long each request is taking.

Here's a very short change which adds an extra attribute to the record event with the time taken for the request. I'm not particularlly tied to this implemention and so another option might be to add a "start" event, which would allow the timing of the requests outside of the library.

If you're happy with the change then i'm ok if you add changes directly to the PR or let me know any cahnges you'd like.